### PR TITLE
Build FONS with FreeType

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 pkgs.haskellPackages.callCabal2nixWithOptions "nanovg" ./. "-fexamples" {
   GLEW = null;
+  inherit (pkgs) freetype;
   inherit (pkgs) glew;
   inherit (pkgs) libGL;
   inherit (pkgs) libGLU;

--- a/nanovg.cabal
+++ b/nanovg.cabal
@@ -81,13 +81,13 @@ library
   c-sources:           nanovg/src/nanovg.c
                        cbits/nanovg_wrapper.c
                        cbits/nanovg_gl.c
-  cc-options:          -DNDEBUG
+  cc-options:          -DNDEBUG -DFONS_USE_FREETYPE
   ghc-options:         -Wall
   if os(osx)
     frameworks:          OpenGL
     cc-options:          -Ddarwin_HOST_OS
   else
-    extra-libraries:     GLU, GL, m, GLEW, X11
+    extra-libraries:     GLU, GL, m, GLEW, X11, freetype
     pkgconfig-depends: glew
   if flag(gles3)
     cpp-options:       -DGLES_3


### PR DESCRIPTION
Adds `-DFONS_USE_FREETYPE` so font rendering uses FreeType internally.

Contains #10.

Not sure about os-x.