### PR TITLE
Fix createFontMem to not use garbage-collected memory

### DIFF
--- a/src/NanoVG/Internal/FFIHelpers.hs
+++ b/src/NanoVG/Internal/FFIHelpers.hs
@@ -2,7 +2,6 @@ module NanoVG.Internal.FFIHelpers
   (withCString
   ,useAsCStringLen'
   ,useAsPtr
-  ,zero
   ,one
   ,null
   ,bitMask
@@ -41,10 +40,6 @@ useAsCStringLen' bs f = useAsCStringLen bs ((\(ptr,len) -> return (castPtr ptr,f
 -- | Wrapper around 'useAsCStringLen'' that discards the length
 useAsPtr :: ByteString -> (Ptr CUChar -> IO a) -> IO a
 useAsPtr bs f = useAsCStringLen' bs (f . fst)
-
--- | Marshalling helper for a constant zero
-zero :: Num a => (a -> b) -> b
-zero f = f 0
 
 -- | Marshalling helper for a constant one
 one :: Num a => (a -> b) -> b

--- a/src/NanoVG/Internal/FFIHelpers.hs
+++ b/src/NanoVG/Internal/FFIHelpers.hs
@@ -29,6 +29,8 @@ useAsCStringLen' bs f = useAsCStringLen bs ((\(ptr,len) -> return (castPtr ptr,f
   where
     -- | Copy memory under given pointer to a new address.
     -- The allocated memory is not garbage-collected and needs to be freed manually later.
+    -- In the case of 'createFontMem' and 'createFontMemAtIndex' (the only places using it)
+    -- it is freed by NanoVG as a part of 'nvgDeleteGL3'.
     copyCStringLen :: Integral b => (Ptr a, b) -> IO (Ptr a, b)
     copyCStringLen (from, len) =
       let intLen = fromIntegral len

--- a/src/NanoVG/Internal/FFIHelpers.hs
+++ b/src/NanoVG/Internal/FFIHelpers.hs
@@ -3,10 +3,12 @@ module NanoVG.Internal.FFIHelpers
   ,useAsCStringLen'
   ,useAsPtr
   ,zero
+  ,one
   ,null
   ,bitMask
   ) where
 
+import           Control.Monad ((>=>))
 import           Data.Bits ((.|.))
 import           Data.ByteString hiding (null)
 import qualified Data.Set as S
@@ -14,6 +16,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import           Foreign.C.String (CString)
 import           Foreign.C.Types
+import           Foreign.Marshal (copyBytes, mallocBytes)
 import           Foreign.Ptr
 import           Prelude hiding (null)
 
@@ -23,7 +26,17 @@ withCString t = useAsCString (T.encodeUtf8 t)
 
 -- | Wrapper around 'useAsCStringLen' that uses 'CUChar's
 useAsCStringLen' :: ByteString -> ((Ptr CUChar,CInt) -> IO a) -> IO a
-useAsCStringLen' bs f = useAsCStringLen bs (\(ptr,len) -> f (castPtr ptr,fromIntegral len))
+useAsCStringLen' bs f = useAsCStringLen bs ((\(ptr,len) -> return (castPtr ptr,fromIntegral len)) >=> copyCStringLen >=> f)
+  where
+    -- | Copy memory under given pointer no a new address.
+    -- The allocated memory is not garbage-collected and needs to be freed manually later.
+    copyCStringLen :: Integral b => (Ptr a, b) -> IO (Ptr a, b)
+    copyCStringLen (from, len) =
+      let intLen = fromIntegral len
+      in do
+        to <- mallocBytes intLen
+        copyBytes to from intLen
+        return (to, len)
 
 -- | Wrapper around 'useAsCStringLen'' that discards the length
 useAsPtr :: ByteString -> (Ptr CUChar -> IO a) -> IO a
@@ -32,6 +45,10 @@ useAsPtr bs f = useAsCStringLen' bs (f . fst)
 -- | Marshalling helper for a constant zero
 zero :: Num a => (a -> b) -> b
 zero f = f 0
+
+-- | Marshalling helper for a constant one
+one :: Num a => (a -> b) -> b
+one f = f 1
 
 -- | Marshalling helper for a constant 'nullPtr'
 null :: (Ptr a -> b) -> b

--- a/src/NanoVG/Internal/FFIHelpers.hs
+++ b/src/NanoVG/Internal/FFIHelpers.hs
@@ -27,7 +27,7 @@ withCString t = useAsCString (T.encodeUtf8 t)
 useAsCStringLen' :: ByteString -> ((Ptr CUChar,CInt) -> IO a) -> IO a
 useAsCStringLen' bs f = useAsCStringLen bs ((\(ptr,len) -> return (castPtr ptr,fromIntegral len)) >=> copyCStringLen >=> f)
   where
-    -- | Copy memory under given pointer no a new address.
+    -- | Copy memory under given pointer to a new address.
     -- The allocated memory is not garbage-collected and needs to be freed manually later.
     copyCStringLen :: Integral b => (Ptr a, b) -> IO (Ptr a, b)
     copyCStringLen (from, len) =

--- a/src/NanoVG/Internal/Text.chs
+++ b/src/NanoVG/Internal/Text.chs
@@ -108,7 +108,7 @@ safeFont i
 -- | Creates image by loading it from the specified memory chunk.
 -- Returns handle to the font.
 {#fun unsafe nvgCreateFontMem as createFontMem
-        {`Context',withCString*`T.Text',useAsCStringLen'*`ByteString'&,zero-`CInt'} -> `Maybe Font'safeFont#}
+        {`Context',withCString*`T.Text',useAsCStringLen'*`ByteString'&,one-`CInt'} -> `Maybe Font'safeFont#}
 
 -- | Creates image by loading it from the specified memory chunk.
 -- fontIndex specifies which font face to load from a .ttf/.ttc file.

--- a/src/NanoVG/Internal/Text.chs
+++ b/src/NanoVG/Internal/Text.chs
@@ -105,12 +105,12 @@ safeFont i
 {#fun unsafe nvgCreateFontAtIndex as createFontAtIndex
         {`Context',withCString*`T.Text','withCString.unwrapFileName'*`FileName', `CInt'} -> `Maybe Font'safeFont#}
 
--- | Creates image by loading it from the specified memory chunk.
+-- | Creates font by loading it from the specified memory chunk.
 -- Returns handle to the font.
 {#fun unsafe nvgCreateFontMem as createFontMem
         {`Context',withCString*`T.Text',useAsCStringLen'*`ByteString'&,one-`CInt'} -> `Maybe Font'safeFont#}
 
--- | Creates image by loading it from the specified memory chunk.
+-- | Creates font by loading it from the specified memory chunk.
 -- fontIndex specifies which font face to load from a .ttf/.ttc file.
 -- Returns handle to the font.
 {#fun unsafe nvgCreateFontMemAtIndex as createFontMemAtIndex

--- a/src/NanoVG/Internal/Text.chs
+++ b/src/NanoVG/Internal/Text.chs
@@ -114,7 +114,7 @@ safeFont i
 -- fontIndex specifies which font face to load from a .ttf/.ttc file.
 -- Returns handle to the font.
 {#fun unsafe nvgCreateFontMemAtIndex as createFontMemAtIndex
-        {`Context',withCString*`T.Text',useAsCStringLen'*`ByteString'&,zero-`CInt',`CInt'} -> `Maybe Font'safeFont#}
+        {`Context',withCString*`T.Text',useAsCStringLen'*`ByteString'&,one-`CInt',`CInt'} -> `Maybe Font'safeFont#}
 
 -- | Finds a loaded font of specified name, and returns handle to it, or -1 if the font is not found.
 {#fun unsafe nvgFindFont as findFont


### PR DESCRIPTION
I've had problems when using `createFontMem`. I didn't use the action directly, but via the monomer library (see the related PR there - https://github.com/fjvallarino/monomer/pull/199#issuecomment-1206635901). Long story short, text wouldn't render when I used `createFontMem` but would with `createFont` and the same file.

What I believe is happening: while the font is in memory when `fonsAddFontMem` is called, it very likely is garbage-collected after the FFI call finishes. The freed memory is reused for another purpose by the Haskell runtime, but from the C point of view the pointer is still valid. When the font is to be used, the same pointer is used (now pointing to gibberish) and the text isn't rendered - garbage in, garbage out.

I tried proving it, but ended up in the FreeType internals which was just a bit too much for me. I have a non-functional monomer example though, which the changes here fix (see [the linked PR](https://github.com/fjvallarino/monomer/pull/199)).

---

The binding tells `fontstash` that it manages the memory of the font bytes on its own (by passing `0` to the `freeData` argument):
https://github.com/cocreature/nanovg-hs/blob/cc8dfa0dc18a0792786c973b4e9a232fa7d3ecfd/src/NanoVG/Internal/Text.chs#L107-L112
The solution is to tell `fontstash` to manage the memory allocated for font bytes and to malloc it manually, so that it's not garbage-collected. Note that's also what `fonsAddFont` does - https://github.com/cocreature/nanovg-hs/blob/cc8dfa0dc18a0792786c973b4e9a232fa7d3ecfd/nanovg/src/fontstash.h#L922-L929

Happy to hear your thoughts.