### PR TITLE
Update FFIHelpers.hs

### DIFF
--- a/src/NanoVG/Internal/FFIHelpers.hs
+++ b/src/NanoVG/Internal/FFIHelpers.hs
@@ -39,9 +39,9 @@ useAsCStringLen' bs f = useAsCStringLen bs ((\(ptr,len) -> return (castPtr ptr,f
         copyBytes to from intLen
         return (to, len)
 
--- | Wrapper around 'useAsCStringLen'' that discards the length
+-- | Wrapper around 'useAsCStringLen' that uses 'CUChar's and discards the length
 useAsPtr :: ByteString -> (Ptr CUChar -> IO a) -> IO a
-useAsPtr bs f = useAsCStringLen' bs (f . fst)
+useAsPtr bs f = useAsCStringLen bs $ \(ptr, _) -> f . castPtr $ ptr
 
 -- | Marshalling helper for a constant one
 one :: Num a => (a -> b) -> b


### PR DESCRIPTION
    Changed the implementation of useAsPtr to not rely on useAsCStringLen'.
    
    The latest PR #17 introduced additional memory allocations when using useAsCStringLen'
    which are not reflected in the documentation of useAsPtr and may lead to
    memory leaks as a consequence.
    
    Changing the implementation of useAsPtr allows for the same behavior but
    the given ByteString's pointer may now be garbage collected after useAsPtr is called.
    This has been the case historically and allows for use of the function createImageRGBA
    (which is the only function using useAsPtr) without a memory leak.