### PR TITLE
createImageRGBA memory leak

### DIFF
--- a/src/NanoVG/Internal/FFIHelpers.hs
+++ b/src/NanoVG/Internal/FFIHelpers.hs
@@ -39,9 +39,9 @@ useAsCStringLen' bs f = useAsCStringLen bs ((\(ptr,len) -> return (castPtr ptr,f
         copyBytes to from intLen
         return (to, len)
 
--- | Wrapper around 'useAsCStringLen'' that discards the length
+-- | Wrapper around 'useAsCStringLen' that uses 'CUChar's and discards the length
 useAsPtr :: ByteString -> (Ptr CUChar -> IO a) -> IO a
-useAsPtr bs f = useAsCStringLen' bs (f . fst)
+useAsPtr bs f = useAsCStringLen bs $ \(ptr, _) -> f . castPtr $ ptr
 
 -- | Marshalling helper for a constant one
 one :: Num a => (a -> b) -> b

--- a/src/NanoVG/Internal/FFIHelpers.hs
+++ b/src/NanoVG/Internal/FFIHelpers.hs
@@ -39,9 +39,9 @@ useAsCStringLen' bs f = useAsCStringLen bs ((\(ptr,len) -> return (castPtr ptr,f
         copyBytes to from intLen
         return (to, len)
 
--- | Wrapper around 'useAsCStringLen' that uses 'CUChar's and discards the length
+-- | Wrapper around 'useAsCStringLen'' that discards the length
 useAsPtr :: ByteString -> (Ptr CUChar -> IO a) -> IO a
-useAsPtr bs f = useAsCStringLen bs $ \(ptr, _) -> f . castPtr $ ptr
+useAsPtr bs f = useAsCStringLen' bs (f . fst)
 
 -- | Marshalling helper for a constant one
 one :: Num a => (a -> b) -> b

--- a/src/NanoVG/Internal/Image.chs
+++ b/src/NanoVG/Internal/Image.chs
@@ -30,7 +30,7 @@ safeImage i
 
 -- | Creates image by loading it from the specified chunk of memory.
 {#fun unsafe nvgCreateImageMem as createImageMem
-        {`Context',bitMask`S.Set ImageFlags',useAsCStringLen'*`ByteString'&} -> `Maybe Image'safeImage#}
+        {`Context',bitMask`S.Set ImageFlags',useAsGCedCStringLen*`ByteString'&} -> `Maybe Image'safeImage#}
 
 -- | Creates image from specified image data.
 {#fun unsafe nvgCreateImageRGBA as createImageRGBA


### PR DESCRIPTION
Added a new function `useAsGCedCStringLen` which restores functionality of the previous version of `useAsCStringLen'`. Primarily, that the ByteString given to that function is still garbage collected by Haskell.

I changed the functions `useAsPtr` and `createImageMem` to use this new function. Since neither of these were marked as effected by the previous release, specifically PR #17, I believe that the resulting changes to their behavior is a bug. I was hoping to align them to their previous functionality without altering any changes made in the latest release.