### PR TITLE
Update text and vector upper bounds

### DIFF
--- a/nanovg.cabal
+++ b/nanovg.cabal
@@ -72,8 +72,8 @@ library
   build-depends:       base >= 4.8 && <5.0
                      , bytestring >= 0.10 && < 0.12
                      , containers >= 0.5 && < 0.7
-                     , text >= 1.2 && < 1.3
-                     , vector >= 0.11 && < 0.13
+                     , text >= 1.2 && < 2.1
+                     , vector >= 0.11 && < 0.14
   hs-source-dirs:      src
   default-language:    Haskell2010
   include-dirs:        nanovg/src


### PR DESCRIPTION
The latest version of Stackage (GHC 9.4) uses `text` and `vector` versions that are out of range for what is defined in `nanovg.cabal`. The new versions still compile without issues, and `example00` runs well.

Since no versions of GHC 8.10.4 for Mac M1 exist, for local testing I updated `stack.yaml` to point to LTS `20.21` (GHC 9.2). I also tested against the latest nightly, `nightly-2023-05-17`, which uses GHC 9.4. Both versions work without issues.

I took the liberty of updating the bounds on Hackage, but I think having this reflected in the repository is safer in case newer versions are released.

Thanks!